### PR TITLE
Replace use of deprecated package analysis with a newer one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 `isFileGenerated` checks if a file is generated. A file is generated if
 
-- [github.com/shurcooL/go/analysis#IsFileGenerated](https://godoc.org/github.com/shurcooL/go/analysis#IsFileGenerated) returns true, or
-- path contains a directory labelled `testdata`.
+- file contains a "// Code generated … DO NOT EDIT." line comment, as specified at https://golang.org/s/generatedcode, or
+- path contains a directory named `vendor`, or
+- path starts with a directory named `Godeps`, or
+- path contains a directory named `testdata`.
 
 Sets the exit status 0 if file is generated, 1 if not generated, or > 1 for other error.
 
@@ -32,4 +34,3 @@ isFileGenerated $GOPATH/src/github.com/hydroflame/fuzzi vendor/github.com/go-kit
 github.com/hydroflame/fuzzi/vendor/github.com/go-kit/kit/endpoint/endpoint.go was generated
 0
 ```
-

--- a/main.go
+++ b/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/shurcooL/go/analysis"
+	"github.com/shurcooL/go/generated"
 )
 
 func main() {
@@ -14,13 +15,15 @@ func main() {
 		os.Exit(2)
 	}
 
-	generated, err := analysis.IsFileGenerated(os.Args[1], os.Args[2])
+	generated, err := generated.ParseFile(filepath.Join(os.Args[1], os.Args[2]))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error checking if %q is generated: %v\n", os.Args[2], err)
+		fmt.Fprintf(os.Stderr, "error checking if %q has generated comment: %v\n", os.Args[2], err)
 		os.Exit(3)
 	}
 
-	if strings.HasPrefix(os.Args[2], "testdata/") || strings.Contains(os.Args[2], "/testdata/") {
+	if strings.HasPrefix(os.Args[2], "vendor/") || strings.Contains(os.Args[2], "/vendor/") ||
+		strings.HasPrefix(os.Args[2], "Godeps/") ||
+		strings.HasPrefix(os.Args[2], "testdata/") || strings.Contains(os.Args[2], "/testdata/") {
 		generated = true
 	}
 


### PR DESCRIPTION
Package [`analysis`](https://godoc.org/github.com/shurcooL/go/analysis) has been deprecated. It's old, and was created as an ad-hoc best-effort solution before there was a specification for declaring a .go file as generated.

It has been superseded by package [`github.com/shurcooL/go/generated`](https://godoc.org/github.com/shurcooL/go/generated), which implements that specification.

This change updates the code and README to use the newer package. The behavior is preserved as much as possible, but it should be more accurate at detecting the `// Code generated … DO NOT EDIT.` comment.